### PR TITLE
Add manual spec options for libcuda, libcupti, and CUDA path

### DIFF
--- a/src/tool/hpcrun/gpu/nvidia/cuda-api.h
+++ b/src/tool/hpcrun/gpu/nvidia/cuda-api.h
@@ -87,7 +87,8 @@ typedef struct cuda_device_property {
 int
 cuda_bind
 (
- void
+ char* manual_libcuda_path,
+ char* manual_cuda_path
 );
 
 

--- a/src/tool/hpcrun/gpu/nvidia/cupti-api.h
+++ b/src/tool/hpcrun/gpu/nvidia/cupti-api.h
@@ -96,7 +96,8 @@ typedef enum {
 int
 cupti_bind
 (
- void
+ char *manual_libcupti_path,
+ char *manual_cuda_path
 );
 
 


### PR DESCRIPTION
Enhance hpctoolkit with options for custom paths to libcuda.so, libcupti.so, and CUDA to improve driver compatibility. 

Use ```-e gpu=nvidia,libcuda_path=/custom/path/libcuda.so``` to set libcuda.so path,
```-e gpu=nvidia,libcupti_path=/custom/path/libcupti.so``` to set libcupti.so path, 
and ```-e gpu=nvidia,cuda_path=/path/to/cudatoolkit``` to set CUDA_PATH

Fixes: #27